### PR TITLE
Add configurable minimum healthy percentage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,18 @@ autoscale 'app-autoscale-group', rolling: true    # default: use rolling deploym
 autoscale 'web-autoscale-group', rolling: false   # override: use normal deployment
 ```
 
+### Deploy with a custom percentage of minimum healthy instances during the instance refresh
+
+The instance refresh is triggered by default with a requirement of 100% minimum healthy instances. ie. One instance is replaced at a time, and must be healthy and in-service before the next is replaced. This can mean that instance refreshes take a long time to complete, especially with larger numbers of instances with large warmup values. Reducing this value allows more instances to be terminated and new instances to be brought up at once during the instance refresh. eg. a value of 0 would terminate all instances in the autoscaling group and replace them at once.
+
+You can configure the minimum healthy percentage per autoscaling group using the `healthy_percentage` option:
+
+```ruby
+# config/deploy/<stage>.rb
+autoscale 'app-autoscale-group', user: 'deployer'                           # default: use standard deployment with 100% minimum healthy instances
+autoscale 'web-autoscale-group', user: 'deployer', healthy_percentage: 75   # override: allow 25% of instances to be terminated and replaced at once
+```
+
 ### Custom stage
 
 The rolling configuration of the stage has a side-effect: any Capistrano tasks you run, will also launch instances per Auto Scaling Group.

--- a/lib/capistrano/asg/rolling/autoscale_group.rb
+++ b/lib/capistrano/asg/rolling/autoscale_group.rb
@@ -40,6 +40,10 @@ module Capistrano
           aws_autoscaling_group.health_check_grace_period
         end
 
+        def healthy_percentage
+          properties.fetch(:healthy_percentage, 100)
+        end
+
         def start_instance_refresh(launch_template)
           aws_autoscaling_client.start_instance_refresh(
             auto_scaling_group_name: name,
@@ -52,7 +56,7 @@ module Capistrano
             },
             preferences: {
               instance_warmup: instance_warmup_time,
-              min_healthy_percentage: 100,
+              min_healthy_percentage: healthy_percentage,
               skip_matching: true
             }
           )

--- a/spec/capistrano/asg/rolling/autoscale_group_spec.rb
+++ b/spec/capistrano/asg/rolling/autoscale_group_spec.rb
@@ -61,6 +61,22 @@ RSpec.describe Capistrano::ASG::Rolling::AutoscaleGroup do
     end
   end
 
+  describe '#healthy_percentage' do
+    context 'when no value is set' do
+      it 'returns the default healthy percentage (100)' do
+        expect(group.healthy_percentage).to eq(100)
+      end
+    end
+
+    context 'when a value is set' do
+      subject(:group) { described_class.new('test-asg', healthy_percentage: 50) }
+
+      it 'returns the value set in the configuration (50)' do
+        expect(group.healthy_percentage).to eq(50)
+      end
+    end
+  end
+
   describe '#start_instance_refresh' do
     let(:template) { Capistrano::ASG::Rolling::LaunchTemplate.new('lt-1234567890', 1, 'MyLaunchTemplate') }
 


### PR DESCRIPTION
Thought it would be useful to have min healthy percentage as a configurable item on a per-asg basis. 

Shouldn't change any functionality - omission just sets the value to the present default.