### PR TITLE
Monitor instance refresh status as part of deployment process

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ When launching an Instance, you can override any settings defined in the Launch 
 set :asg_rolling_instance_overrides, { instance_type: 'c5.large' }
 ```
 
+You can make Capistrano wait until the instances in the autoscaling group have completed refreshing with:
+
+```ruby
+# config/deploy.rb
+set :asg_wait_for_instance_refresh, true
+set :asg_instance_refresh_polling_interval, 30 # default
+```
+
 ## Usage
 
 Specify the Auto Scaling Groups with the keyword `autoscale` instead of using the `server` keyword in Capistrano's stage configuration. Provide the name of the Auto Scaling Group and any properties you want to pass to the server:

--- a/lib/capistrano/asg/rolling/autoscale_group.rb
+++ b/lib/capistrano/asg/rolling/autoscale_group.rb
@@ -12,7 +12,9 @@ module Capistrano
         LIFECYCLE_STATE_IN_SERVICE = 'InService'
         LIFECYCLE_STATE_STANDBY = 'Standby'
 
-        attr_reader :name, :properties
+        INSTANCE_REFRESH_COMPLETED_STATUS = 100
+
+        attr_reader :name, :properties, :refresh_id
 
         def initialize(name, properties = {})
           @name = name
@@ -42,10 +44,6 @@ module Capistrano
 
         def healthy_percentage
           properties.fetch(:healthy_percentage, 100)
-        end
-
-        def refresh_id
-          @refresh_id
         end
 
         def start_instance_refresh(launch_template)
@@ -118,13 +116,12 @@ module Capistrano
         def most_recent_instance_refresh
           parameters = {
             auto_scaling_group_name: name,
-            max_records: 1,
+            max_records: 1
           }
           parameters[:instance_refresh_ids] = [@refresh_id] if @refresh_id
           refresh = aws_autoscaling_client.describe_instance_refreshes(parameters).to_h
           refresh[:instance_refreshes].first
         end
-
 
         def aws_autoscaling_group
           @aws_autoscaling_group ||= ::Aws::AutoScaling::AutoScalingGroup.new(name: name, client: aws_autoscaling_client)

--- a/lib/capistrano/asg/rolling/autoscale_group.rb
+++ b/lib/capistrano/asg/rolling/autoscale_group.rb
@@ -44,6 +44,10 @@ module Capistrano
           properties.fetch(:healthy_percentage, 100)
         end
 
+        def refresh_id
+          @refresh_id
+        end
+
         def start_instance_refresh(launch_template)
           @refresh_id = aws_autoscaling_client.start_instance_refresh(
             auto_scaling_group_name: name,

--- a/lib/capistrano/asg/rolling/autoscale_group.rb
+++ b/lib/capistrano/asg/rolling/autoscale_group.rb
@@ -72,7 +72,7 @@ module Capistrano
           {
             status: status,
             percentage_complete: instance_refresh&.dig(:percentage_complete),
-            completed: COMPLETED_REFRESH_STATUSES.include?(status),
+            completed: COMPLETED_REFRESH_STATUSES.include?(status)
           }
         end
 

--- a/lib/capistrano/asg/rolling/autoscale_group.rb
+++ b/lib/capistrano/asg/rolling/autoscale_group.rb
@@ -12,7 +12,7 @@ module Capistrano
         LIFECYCLE_STATE_IN_SERVICE = 'InService'
         LIFECYCLE_STATE_STANDBY = 'Standby'
 
-        INSTANCE_REFRESH_COMPLETED_STATUS = 100
+        COMPLETED_REFRESH_STATUSES = %w[Successful Cancelled Failed RollbackFailed].freeze
 
         attr_reader :name, :properties, :refresh_id
 

--- a/lib/capistrano/asg/rolling/autoscale_group.rb
+++ b/lib/capistrano/asg/rolling/autoscale_group.rb
@@ -68,7 +68,12 @@ module Capistrano
 
         def latest_instance_refresh
           instance_refresh = most_recent_instance_refresh
-          { status: instance_refresh&.dig(:status), percentage_complete: instance_refresh&.dig(:percentage_complete) }
+          status = instance_refresh&.dig(:status)
+          {
+            status: status,
+            percentage_complete: instance_refresh&.dig(:percentage_complete),
+            completed: COMPLETED_REFRESH_STATUSES.include?(status),
+          }
         end
 
         # Returns instances with lifecycle state "InService" for this Auto Scaling Group.

--- a/lib/capistrano/asg/rolling/plugin.rb
+++ b/lib/capistrano/asg/rolling/plugin.rb
@@ -28,6 +28,7 @@ module Capistrano
 
           after 'rolling:update', 'rolling:cleanup'
           after 'rolling:create_ami', 'rolling:cleanup'
+          after 'rolling:update',  'rolling:instance_refresh_status'
 
           # Register an exit hook to do some cleanup when Capistrano
           # terminates without calling our after cleanup hook.

--- a/lib/capistrano/asg/tasks/rolling.rake
+++ b/lib/capistrano/asg/tasks/rolling.rake
@@ -182,8 +182,7 @@ namespace :rolling do
         refresh = group.latest_instance_refresh
         status = refresh[:status]
         percentage_complete = refresh[:percentage_complete]
-        completed_statuses = %w[Successful Cancelled Failed RollbackFailed]
-        refresh_completed = completed_statuses.include?(status)
+        refresh_completed = Capistrano::ASG::Rolling::AutoscaleGroup::COMPLETED_REFRESH_STATUSES.include?(status)
         if refresh.nil? || refresh_completed == true
           logger.info "Auto Scaling Group: **#{group.name}**, completed with status '#{status}'"
           groups.delete(group.name)

--- a/lib/capistrano/asg/tasks/rolling.rake
+++ b/lib/capistrano/asg/tasks/rolling.rake
@@ -193,11 +193,11 @@ namespace :rolling do
           logger.info "Auto Scaling Group: **#{name}**, status '#{status}'"
         end
       end
-      if groups.count.positive?
-        wait_for = fetch(:asg_instance_refresh_polling_interval, 30)
-        logger.info "Instance refresh(es) not completed, waiting #{wait_for} seconds"
-        sleep wait_for
-      end
+      next unless groups.count.positive?
+
+      wait_for = fetch(:asg_instance_refresh_polling_interval, 30)
+      logger.info "Instance refresh(es) not completed, waiting #{wait_for} seconds"
+      sleep wait_for
     end
   end
 end

--- a/lib/capistrano/asg/tasks/rolling.rake
+++ b/lib/capistrano/asg/tasks/rolling.rake
@@ -193,11 +193,10 @@ namespace :rolling do
         end
 
         next unless groups.count.positive?
-
-        wait_for = fetch(:asg_instance_refresh_polling_interval, 30)
-        logger.info "Instance refresh(es) not completed, waiting #{wait_for} seconds"
-        sleep wait_for
       end
+      wait_for = fetch(:asg_instance_refresh_polling_interval, 30)
+      logger.info "Instance refresh(es) not completed, waiting #{wait_for} seconds"
+      sleep wait_for
     end
   end
 end

--- a/lib/capistrano/asg/tasks/rolling.rake
+++ b/lib/capistrano/asg/tasks/rolling.rake
@@ -176,20 +176,21 @@ namespace :rolling do
 
   desc 'Get status of instance refresh'
   task :instance_refresh_status do
-    groups = config.autoscale_groups.map(&:name)
+    groups = {}
+    config.autoscale_groups.each { |group| groups[group.name] = group }
     while groups.count.positive?
-      config.autoscale_groups.each do |group|
+      groups.each do |name, group|
         refresh = group.latest_instance_refresh
         status = refresh[:status]
         percentage_complete = refresh[:percentage_complete]
         refresh_completed = Capistrano::ASG::Rolling::AutoscaleGroup::COMPLETED_REFRESH_STATUSES.include?(status)
         if refresh.nil? || refresh_completed == true
-          logger.info "Auto Scaling Group: **#{group.name}**, completed with status '#{status}'"
-          groups.delete(group.name)
+          logger.info "Auto Scaling Group: **#{name}**, completed with status '#{status}'"
+          groups.delete(name)
         elsif !percentage_complete.nil?
-          logger.info "Auto Scaling Group: **#{group.name}**, #{percentage_complete}% completed, #{status}"
+          logger.info "Auto Scaling Group: **#{name}**, #{percentage_complete}% completed, #{status}"
         else
-          logger.info "Auto Scaling Group: **#{group.name}**, status '#{status}'"
+          logger.info "Auto Scaling Group: **#{name}**, status '#{status}'"
         end
 
         next unless groups.count.positive?

--- a/lib/capistrano/asg/tasks/rolling.rake
+++ b/lib/capistrano/asg/tasks/rolling.rake
@@ -192,12 +192,12 @@ namespace :rolling do
         else
           logger.info "Auto Scaling Group: **#{name}**, status '#{status}'"
         end
-
-        next unless groups.count.positive?
       end
-      wait_for = fetch(:asg_instance_refresh_polling_interval, 30)
-      logger.info "Instance refresh(es) not completed, waiting #{wait_for} seconds"
-      sleep wait_for
+      if groups.count.positive?
+        wait_for = fetch(:asg_instance_refresh_polling_interval, 30)
+        logger.info "Instance refresh(es) not completed, waiting #{wait_for} seconds"
+        sleep wait_for
+      end
     end
   end
 end

--- a/lib/capistrano/asg/tasks/rolling.rake
+++ b/lib/capistrano/asg/tasks/rolling.rake
@@ -183,8 +183,8 @@ namespace :rolling do
         refresh = group.latest_instance_refresh
         status = refresh[:status]
         percentage_complete = refresh[:percentage_complete]
-        refresh_completed = Capistrano::ASG::Rolling::AutoscaleGroup::COMPLETED_REFRESH_STATUSES.include?(status)
-        if refresh.nil? || refresh_completed == true
+        refresh_completed =
+        if refresh.nil? || refresh[:completed]
           logger.info "Auto Scaling Group: **#{name}**, completed with status '#{status}'"
           groups.delete(name)
         elsif !percentage_complete.nil?

--- a/lib/capistrano/asg/tasks/rolling.rake
+++ b/lib/capistrano/asg/tasks/rolling.rake
@@ -115,7 +115,6 @@ namespace :rolling do
     rescue Aws::Errors::ServiceError => e
       logger.warning "Error deleting instance: #{e}"
     end
-    invoke 'rolling:instance_refresh_status' if fetch(:asg_wait_for_instance_refresh)
   end
 
   desc 'Launch Instances by marking instances to not automatically terminate'
@@ -176,6 +175,7 @@ namespace :rolling do
 
   desc 'Get status of instance refresh'
   task :instance_refresh_status do
+    return unless fetch(:asg_wait_for_instance_refresh)
     groups = {}
     config.autoscale_groups.each { |group| groups[group.name] = group }
     while groups.count.positive?

--- a/lib/capistrano/asg/tasks/rolling.rake
+++ b/lib/capistrano/asg/tasks/rolling.rake
@@ -112,7 +112,7 @@ namespace :rolling do
         logger.info 'Terminating instance(s)...'
         instances.terminate
       end
-    rescue => error
+    rescue Aws::Errors::ServiceError => error
       logger.warning "Error deleting instance: #{error}"
     end
     invoke 'rolling:instance_refresh_status' if fetch(:asg_wait_for_instance_refresh)

--- a/lib/capistrano/asg/tasks/rolling.rake
+++ b/lib/capistrano/asg/tasks/rolling.rake
@@ -176,6 +176,7 @@ namespace :rolling do
   desc 'Get status of instance refresh'
   task :instance_refresh_status do
     return unless fetch(:asg_wait_for_instance_refresh)
+
     groups = {}
     config.autoscale_groups.each { |group| groups[group.name] = group }
     while groups.count.positive?
@@ -183,7 +184,6 @@ namespace :rolling do
         refresh = group.latest_instance_refresh
         status = refresh[:status]
         percentage_complete = refresh[:percentage_complete]
-        refresh_completed =
         if refresh.nil? || refresh[:completed]
           logger.info "Auto Scaling Group: **#{name}**, completed with status '#{status}'"
           groups.delete(name)

--- a/spec/capistrano/asg/rolling/autoscale_group_spec.rb
+++ b/spec/capistrano/asg/rolling/autoscale_group_spec.rb
@@ -181,12 +181,12 @@ RSpec.describe Capistrano::ASG::Rolling::AutoscaleGroup do
   end
 
   describe '#latest_instance_refresh' do
-    context 'a refresh has been triggered' do
+    context 'when run as part of a deployment' do
       let(:template) { Capistrano::ASG::Rolling::LaunchTemplate.new('lt-1234567890', 1, 'MyLaunchTemplate') }
 
       before do
         stub_request(:post, /amazonaws.com/)
-        .with(body: /Action=StartInstanceRefresh&AutoScalingGroupName=test-asg/).to_return(body: File.read('spec/support/stubs/StartInstanceRefresh.xml'))
+          .with(body: /Action=StartInstanceRefresh&AutoScalingGroupName=test-asg/).to_return(body: File.read('spec/support/stubs/StartInstanceRefresh.xml'))
         stub_request(:post, /amazonaws.com/)
           .with(body: /Action=DescribeInstanceRefreshes&AutoScalingGroupName=test-asg/)
           .to_return(body: File.read('spec/support/stubs/DescribeInstanceRefreshes.Pending.xml'))
@@ -195,12 +195,12 @@ RSpec.describe Capistrano::ASG::Rolling::AutoscaleGroup do
 
       it 'returns status and percentage completed' do
         expect(group.latest_instance_refresh).to eq({
-          status: 'Pending', percentage_complete: nil
-        })
+                                                      status: 'Pending', percentage_complete: nil
+                                                    })
       end
     end
 
-    context 'a call without a triggered refresh' do
+    context 'without a triggered refresh' do
       before do
         stub_request(:post, /amazonaws.com/)
           .with(body: /Action=DescribeInstanceRefreshes&AutoScalingGroupName=test-asg/)
@@ -209,8 +209,8 @@ RSpec.describe Capistrano::ASG::Rolling::AutoscaleGroup do
 
       it 'returns status and percentage completed' do
         expect(group.latest_instance_refresh).to eq({
-          status: 'InProgress', percentage_complete: 25
-        })
+                                                      status: 'InProgress', percentage_complete: 25
+                                                    })
       end
     end
   end

--- a/spec/capistrano/asg/rolling/autoscale_group_spec.rb
+++ b/spec/capistrano/asg/rolling/autoscale_group_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe Capistrano::ASG::Rolling::AutoscaleGroup do
       .with(body: /Action=DescribeAutoScalingGroups/).to_return(body: File.read('spec/support/stubs/DescribeAutoScalingGroups.xml'))
   end
 
+  it { expect(described_class::COMPLETED_REFRESH_STATUSES).to eq %w[Successful Cancelled Failed RollbackFailed] }
+
   describe '#exists?' do
     context 'when auto scale group exists' do
       it 'returns true' do

--- a/spec/capistrano/asg/rolling/autoscale_group_spec.rb
+++ b/spec/capistrano/asg/rolling/autoscale_group_spec.rb
@@ -197,7 +197,7 @@ RSpec.describe Capistrano::ASG::Rolling::AutoscaleGroup do
 
       it 'returns status and percentage completed' do
         expect(group.latest_instance_refresh).to eq({
-                                                      status: 'Pending', percentage_complete: nil
+                                                      status: 'Pending', percentage_complete: nil, completed: false
                                                     })
       end
     end
@@ -211,7 +211,7 @@ RSpec.describe Capistrano::ASG::Rolling::AutoscaleGroup do
 
       it 'returns status and percentage completed' do
         expect(group.latest_instance_refresh).to eq({
-                                                      status: 'InProgress', percentage_complete: 25
+                                                      status: 'InProgress', percentage_complete: 25, completed: false
                                                     })
       end
     end

--- a/spec/capistrano/asg/rolling/autoscale_group_spec.rb
+++ b/spec/capistrano/asg/rolling/autoscale_group_spec.rb
@@ -91,6 +91,11 @@ RSpec.describe Capistrano::ASG::Rolling::AutoscaleGroup do
         .with(body: /Action=StartInstanceRefresh&AutoScalingGroupName=test-asg/).once
     end
 
+    it 'sets instance refresh details on the group' do
+      group.start_instance_refresh(template)
+      expect(group.refresh_id).to eq 'ccfd3c2f-edb3-470d-af32-52cc57d201ca'
+    end
+
     context 'when instance refresh is already in progress' do
       before do
         stub_request(:post, /amazonaws.com/)

--- a/spec/capistrano/asg/rolling/plugin_spec.rb
+++ b/spec/capistrano/asg/rolling/plugin_spec.rb
@@ -9,12 +9,17 @@ require 'capistrano/deploy'
 RSpec.describe Capistrano::ASG::Rolling::Plugin do
   include Capistrano::DSL
 
-  it 'defines tasks when constructed' do
+  it 'defines tasks when constructed #1' do
     install_plugin described_class
 
     expect(Rake::Task['rolling:setup']).not_to be_nil
     expect(Rake::Task['rolling:update']).not_to be_nil
     expect(Rake::Task['rolling:cleanup']).not_to be_nil
+  end
+
+  it 'defines tasks when constructed #2' do
+    install_plugin described_class
+
     expect(Rake::Task['rolling:launch_instances']).not_to be_nil
     expect(Rake::Task['rolling:create_ami']).not_to be_nil
     expect(Rake::Task['rolling:instance_refresh_status']).not_to be_nil

--- a/spec/capistrano/asg/rolling/plugin_spec.rb
+++ b/spec/capistrano/asg/rolling/plugin_spec.rb
@@ -17,5 +17,6 @@ RSpec.describe Capistrano::ASG::Rolling::Plugin do
     expect(Rake::Task['rolling:cleanup']).not_to be_nil
     expect(Rake::Task['rolling:launch_instances']).not_to be_nil
     expect(Rake::Task['rolling:create_ami']).not_to be_nil
+    expect(Rake::Task['rolling:instance_refresh_status']).not_to be_nil
   end
 end

--- a/spec/support/stubs/DescribeInstanceRefreshes.InProgress.xml
+++ b/spec/support/stubs/DescribeInstanceRefreshes.InProgress.xml
@@ -1,0 +1,17 @@
+<DescribeInstanceRefreshesResponse xmlns="https://autoscaling.amazonaws.com/doc/2011-01-01/">
+  <DescribeInstanceRefreshesResult>
+    <InstanceRefreshes>
+      <member>
+        <AutoScalingGroupName>my-asg</AutoScalingGroupName>
+        <InstanceRefreshId>08b91cf7-8fa6-48af-b6a6-d227f40f1b9b</InstanceRefreshId>
+        <InstancesToUpdate>5</InstancesToUpdate>
+        <PercentageComplete>25</PercentageComplete>
+        <StartTime>2020-06-02T18:11:27Z</StartTime>
+        <Status>InProgress</Status>
+      </member>
+    </InstanceRefreshes>
+  </DescribeInstanceRefreshesResult>
+  <ResponseMetadata>
+    <RequestId>7c6e177f-f082-11e1-ac58-3714bEXAMPLE</RequestId>
+  </ResponseMetadata>
+</DescribeInstanceRefreshesResponse>

--- a/spec/support/stubs/DescribeInstanceRefreshes.Pending.xml
+++ b/spec/support/stubs/DescribeInstanceRefreshes.Pending.xml
@@ -1,0 +1,14 @@
+<DescribeInstanceRefreshesResponse xmlns="https://autoscaling.amazonaws.com/doc/2011-01-01/">
+  <DescribeInstanceRefreshesResult>
+    <InstanceRefreshes>
+      <member>
+        <AutoScalingGroupName>my-asg</AutoScalingGroupName>
+        <InstanceRefreshId>08b91cf7-8fa6-48af-b6a6-d227f40f1b9b</InstanceRefreshId>
+        <Status>Pending</Status>
+      </member>
+    </InstanceRefreshes>
+  </DescribeInstanceRefreshesResult>
+  <ResponseMetadata>
+    <RequestId>7c6e177f-f082-11e1-ac58-3714bEXAMPLE</RequestId>
+  </ResponseMetadata>
+</DescribeInstanceRefreshesResponse>

--- a/spec/support/stubs/DescribeInstanceRefreshes.Successful.xml
+++ b/spec/support/stubs/DescribeInstanceRefreshes.Successful.xml
@@ -1,0 +1,17 @@
+<DescribeInstanceRefreshesResponse xmlns="https://autoscaling.amazonaws.com/doc/2011-01-01/">
+  <DescribeInstanceRefreshesResult>
+    <InstanceRefreshes>
+      <member>
+        <AutoScalingGroupName>my-asg</AutoScalingGroupName>
+        <InstanceRefreshId>08b91cf7-8fa6-48af-b6a6-d227f40f1b9b</InstanceRefreshId>
+        <InstancesToUpdate>5</InstancesToUpdate>
+        <PercentageComplete>0</PercentageComplete>
+        <StartTime>2020-06-02T18:11:27Z</StartTime>
+        <Status>Successful</Status>
+      </member>
+    </InstanceRefreshes>
+  </DescribeInstanceRefreshesResult>
+  <ResponseMetadata>
+    <RequestId>7c6e177f-f082-11e1-ac58-3714bEXAMPLE</RequestId>
+  </ResponseMetadata>
+</DescribeInstanceRefreshesResponse>


### PR DESCRIPTION
Add the ability to monitor instance refresh progress as part of a deployment.

When switched on Capistrano won't complete until the autoscaling group instance refresh has completed.

Running `cap $env rolling:instance_refresh_status` directly will monitor the status of the most recent instance refresh.