### PR TITLE
Fail deployment if instance refresh fails

### DIFF
--- a/lib/capistrano/asg/tasks/rolling.rake
+++ b/lib/capistrano/asg/tasks/rolling.rake
@@ -114,7 +114,6 @@ namespace :rolling do
         instances.terminate
       rescue Capistrano::ASG::Rolling::InstanceTerminateFailed => e
         logger.warning "Failed to terminate Instance **#{e.instance.id}**: #{e.message}"
-        raise RuntimeError, 'Auto Scaling Group Update Failed.'
       end
     end
   end

--- a/lib/capistrano/asg/tasks/rolling.rake
+++ b/lib/capistrano/asg/tasks/rolling.rake
@@ -125,7 +125,7 @@ namespace :rolling do
       end
     else
       logger.error 'No instances have been launched. Are you using a configuration with rolling deployments?'
-      raise RuntimeError, 'Auto Scaling Group update failed'
+      raise 'Auto Scaling Group update failed'
     end
   end
 
@@ -139,7 +139,7 @@ namespace :rolling do
       end
     else
       logger.error 'No instances have been launched. Are you using a configuration with rolling deployments?'
-      raise RuntimeError, 'Auto Scaling Group update failed'
+      raise 'Auto Scaling Group update failed'
     end
 
     invoke 'deploy'
@@ -206,7 +206,7 @@ namespace :rolling do
           logger.info "Auto Scaling Group: **#{name}**, completed with status '#{refresh.status}'."
         end
       end
-      raise RuntimeError, 'Auto Scaling Group update failed' if failed
+      raise 'Auto Scaling Group update failed' if failed
     end
   end
 end

--- a/lib/capistrano/asg/tasks/rolling.rake
+++ b/lib/capistrano/asg/tasks/rolling.rake
@@ -124,8 +124,7 @@ namespace :rolling do
         instance.auto_terminate = false
       end
     else
-      logger.error 'No instances have been launched. Are you using a configuration with rolling deployments?'
-      raise 'Auto Scaling Group update failed'
+      raise 'No instances have been launched. Are you using a configuration with rolling deployments?'
     end
   end
 
@@ -138,8 +137,7 @@ namespace :rolling do
         instance.auto_terminate = false
       end
     else
-      logger.error 'No instances have been launched. Are you using a configuration with rolling deployments?'
-      raise 'Auto Scaling Group update failed'
+      raise 'No instances have been launched. Are you using a configuration with rolling deployments?'
     end
 
     invoke 'deploy'
@@ -197,15 +195,7 @@ namespace :rolling do
         logger.info "Instance refresh(es) not completed, waiting #{wait_for} seconds..."
         sleep wait_for
       end
-      failed = false
-      completed_groups.each do |group|
-        if group.latest_instance_refresh.status == 'Failed'
-          failed = true
-          logger.error "~~ Auto Scaling Group: **#{name}** refresh failed ~~"
-        else
-          logger.info "Auto Scaling Group: **#{name}**, completed with status '#{refresh.status}'."
-        end
-      end
+      failed = completed_groups.any? { |group| group.latest_instance_refresh.status == 'Failed' }
       raise 'Auto Scaling Group update failed' if failed
     end
   end

--- a/lib/capistrano/asg/tasks/rolling.rake
+++ b/lib/capistrano/asg/tasks/rolling.rake
@@ -64,6 +64,7 @@ namespace :rolling do
           logger.verbose "Successfully started Instance Refresh on Auto Scaling Group **#{group.name}**."
         rescue Capistrano::ASG::Rolling::InstanceRefreshFailed => e
           logger.info "Failed to start Instance Refresh on Auto Scaling Group **#{group.name}**: #{e.message}"
+          raise RuntimeError, 'Auto Scaling Group Update Failed.'
         end
       end
 
@@ -111,8 +112,9 @@ namespace :rolling do
       logger.info 'Terminating instance(s)...'
       begin
         instances.terminate
-      rescue Capistrano::ASG::Rolling::InstanceTerminateFailed => e
+      rescue Capistrano::ASG::Rolling::InstanceTerminateraise => e
         logger.warning "Failed to terminate Instance **#{e.instance.id}**: #{e.message}"
+        raise RuntimeError, 'Auto Scaling Group Update Failed.'
       end
     end
   end
@@ -125,7 +127,7 @@ namespace :rolling do
       end
     else
       logger.error 'No instances have been launched. Are you using a configuration with rolling deployments?'
-      fail
+      raise RuntimeError, 'Auto Scaling Group update failed'
     end
   end
 
@@ -139,7 +141,7 @@ namespace :rolling do
       end
     else
       logger.error 'No instances have been launched. Are you using a configuration with rolling deployments?'
-      fail
+      raise RuntimeError, 'Auto Scaling Group update failed'
     end
 
     invoke 'deploy'
@@ -206,7 +208,7 @@ namespace :rolling do
           logger.info "Auto Scaling Group: **#{name}**, completed with status '#{refresh.status}'."
         end
       end
-      fail if failed
+      raise RuntimeError, 'Auto Scaling Group update failed' if raise RuntimeError, 'Auto Scaling Group update failed'
     end
   end
 end

--- a/lib/capistrano/asg/tasks/rolling.rake
+++ b/lib/capistrano/asg/tasks/rolling.rake
@@ -112,7 +112,7 @@ namespace :rolling do
       logger.info 'Terminating instance(s)...'
       begin
         instances.terminate
-      rescue Capistrano::ASG::Rolling::InstanceTerminateraise => e
+      rescue Capistrano::ASG::Rolling::InstanceTerminateFailed => e
         logger.warning "Failed to terminate Instance **#{e.instance.id}**: #{e.message}"
         raise RuntimeError, 'Auto Scaling Group Update Failed.'
       end

--- a/lib/capistrano/asg/tasks/rolling.rake
+++ b/lib/capistrano/asg/tasks/rolling.rake
@@ -125,7 +125,7 @@ namespace :rolling do
       end
     else
       logger.error 'No instances have been launched. Are you using a configuration with rolling deployments?'
-      exit 1
+      fail
     end
   end
 
@@ -139,7 +139,7 @@ namespace :rolling do
       end
     else
       logger.error 'No instances have been launched. Are you using a configuration with rolling deployments?'
-      exit 1
+      fail
     end
 
     invoke 'deploy'
@@ -206,7 +206,7 @@ namespace :rolling do
           logger.info "Auto Scaling Group: **#{name}**, completed with status '#{refresh.status}'."
         end
       end
-      exit 1 if failed
+      fail if failed
     end
   end
 end

--- a/lib/capistrano/asg/tasks/rolling.rake
+++ b/lib/capistrano/asg/tasks/rolling.rake
@@ -206,7 +206,7 @@ namespace :rolling do
           logger.info "Auto Scaling Group: **#{name}**, completed with status '#{refresh.status}'."
         end
       end
-      raise RuntimeError, 'Auto Scaling Group update failed' if raise RuntimeError, 'Auto Scaling Group update failed'
+      raise RuntimeError, 'Auto Scaling Group update failed' if failed
     end
   end
 end

--- a/lib/capistrano/asg/tasks/rolling.rake
+++ b/lib/capistrano/asg/tasks/rolling.rake
@@ -64,7 +64,6 @@ namespace :rolling do
           logger.verbose "Successfully started Instance Refresh on Auto Scaling Group **#{group.name}**."
         rescue Capistrano::ASG::Rolling::InstanceRefreshFailed => e
           logger.info "Failed to start Instance Refresh on Auto Scaling Group **#{group.name}**: #{e.message}"
-          raise RuntimeError, 'Auto Scaling Group Update Failed.'
         end
       end
 


### PR DESCRIPTION
Currently if an instance refresh completes with a status of "Failed" the deployment still gets marked as successful.

This change raises an error if one (or more) of the autoscaling group refreshes fails.