### PR TITLE
Make AMI availability wait configurable (delay + max attempts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ Enable or disable auto-rollback on instance refreshes (default: false):
 set :asg_instance_refresh_auto_rollback, true
 ```
 
+After creating an AMI, the gem waits until it becomes available before triggering an instance refresh. The defaults match the AWS SDK defaults (~10 minutes), but for larger root volumes (e.g. resizing 24 GB → 32 GB) the AMI can take longer to become available. Override the waiter via:
+
+```ruby
+# config/deploy.rb
+set :asg_ami_wait_delay, 15         # seconds between polls (default: 15)
+set :asg_ami_wait_max_attempts, 40  # max polls (default: 40, ≈ 10 minutes)
+```
+
 ## Usage
 
 Specify the Auto Scaling Groups with the keyword `autoscale` instead of using the `server` keyword in Capistrano's stage configuration. Provide the name of the Auto Scaling Group and any properties you want to pass to the server:

--- a/lib/capistrano/asg/rolling/ami.rb
+++ b/lib/capistrano/asg/rolling/ami.rb
@@ -36,10 +36,14 @@ module Capistrano
           response = aws_ec2_client.create_image(options)
 
           begin
-            aws_ec2_client.wait_until(:image_available, image_ids: [response.image_id])
+            aws_ec2_client.wait_until(:image_available, image_ids: [response.image_id]) do |waiter|
+              waiter.delay = Configuration.ami_wait_delay
+              waiter.max_attempts = Configuration.ami_wait_max_attempts
+            end
           rescue Aws::Waiters::Errors::TooManyAttemptsError
-            # When waiting for the AMI takes longer than the default (10 minutes),
-            # then assume it will eventually succeed and just continue.
+            # When waiting for the AMI exceeds the configured timeout
+            # (see :asg_ami_wait_delay / :asg_ami_wait_max_attempts),
+            # assume it will eventually succeed and just continue.
           end
 
           new(response.image_id, instance)

--- a/lib/capistrano/asg/rolling/configuration.rb
+++ b/lib/capistrano/asg/rolling/configuration.rb
@@ -79,6 +79,14 @@ module Capistrano
         def instance_refresh_polling_interval
           fetch(:asg_instance_refresh_polling_interval, 30)
         end
+
+        def ami_wait_delay
+          fetch(:asg_ami_wait_delay, 15)
+        end
+
+        def ami_wait_max_attempts
+          fetch(:asg_ami_wait_max_attempts, 40)
+        end
       end
     end
   end

--- a/spec/capistrano/asg/rolling/ami_spec.rb
+++ b/spec/capistrano/asg/rolling/ami_spec.rb
@@ -29,6 +29,21 @@ RSpec.describe Capistrano::ASG::Rolling::AMI do
       ami = described_class.create(instance: instance, name: 'Test AMI')
       expect(ami.id).to eq('ami-1234567890EXAMPLE')
     end
+
+    it 'passes the configured delay and max_attempts to the waiter' do
+      Capistrano::ASG::Rolling::Configuration.set(:asg_ami_wait_delay, 5)
+      Capistrano::ASG::Rolling::Configuration.set(:asg_ami_wait_max_attempts, 3)
+
+      waiter = instance_double(Aws::Waiters::Waiter, wait: nil)
+      allow(waiter).to receive(:delay=)
+      allow(waiter).to receive(:max_attempts=)
+      allow(instance.aws_ec2_client).to receive(:wait_until).and_yield(waiter)
+
+      described_class.create(instance: instance, name: 'Test AMI')
+
+      expect(waiter).to have_received(:delay=).with(5)
+      expect(waiter).to have_received(:max_attempts=).with(3)
+    end
   end
 
   describe '#exists?' do


### PR DESCRIPTION
## Summary

`AMI.create` calls `wait_until(:image_available, ...)` which uses the AWS SDK's default wait of ~10 minutes (delay 15s × 40 attempts). When the AMI isn't ready in that window the `TooManyAttemptsError` is rescued silently, the method returns, and the subsequent `start_instance_refresh` call fails because the AMI is still in the `pending` state.

This is reproducible in practice when increasing the root volume size of the source instance (for example 24 GB → 32 GB), which can push AMI creation beyond the 10-minute window.

This PR makes the waiter configurable via two new Capistrano variables:

- `:asg_ami_wait_delay` — seconds between polls (default: 15)
- `:asg_ami_wait_max_attempts` — maximum number of polls (default: 40)

Defaults match the AWS SDK defaults, so existing behaviour is unchanged. Users with larger volumes can raise `:asg_ami_wait_max_attempts` (e.g. 80 for ~20 minutes) to wait long enough for the AMI to become available before the instance refresh is triggered. The existing silent rescue of `TooManyAttemptsError` is preserved.

## Test plan

- [x] `bundle exec rspec` — 142 examples, 0 failures
- [x] `bundle exec rubocop lib spec` — no offenses
- [x] New spec verifies the configured `delay` / `max_attempts` reach the waiter