### PR TITLE
Surface AMI waiter timeouts and wrap AutoScaling errors uniformly

### DIFF
--- a/lib/capistrano/asg/rolling/ami.rb
+++ b/lib/capistrano/asg/rolling/ami.rb
@@ -37,9 +37,13 @@ module Capistrano
 
           begin
             aws_ec2_client.wait_until(:image_available, image_ids: [response.image_id])
-          rescue Aws::Waiters::Errors::TooManyAttemptsError
+          rescue Aws::Waiters::Errors::TooManyAttemptsError => e
             # When waiting for the AMI takes longer than the default (10 minutes),
-            # then assume it will eventually succeed and just continue.
+            # then assume it will eventually succeed and just continue. Surface a
+            # warning so operators can see that the wait did not complete in time
+            # (for example after increasing the root volume size of the source
+            # instance) before the subsequent Instance Refresh is started.
+            Kernel.warn("WARNING: timed out waiting for AMI #{response.image_id} to become available: #{e.message}")
           end
 
           new(response.image_id, instance)

--- a/lib/capistrano/asg/rolling/autoscale_group.rb
+++ b/lib/capistrano/asg/rolling/autoscale_group.rb
@@ -81,7 +81,11 @@ module Capistrano
               auto_rollback: auto_rollback
             }.compact
           ).instance_refresh_id
-        rescue Aws::AutoScaling::Errors::InstanceRefreshInProgress => e
+        rescue Aws::AutoScaling::Errors::ServiceError => e
+          # Wrap all AWS Auto Scaling service errors (InstanceRefreshInProgress,
+          # ValidationError, throttling, etc.) so the rake task can rescue a
+          # single gem-defined error type and continue with the remaining
+          # Auto Scaling Group(s).
           raise Capistrano::ASG::Rolling::StartInstanceRefreshError, e
         end
 

--- a/spec/capistrano/asg/rolling/ami_spec.rb
+++ b/spec/capistrano/asg/rolling/ami_spec.rb
@@ -29,6 +29,20 @@ RSpec.describe Capistrano::ASG::Rolling::AMI do
       ami = described_class.create(instance: instance, name: 'Test AMI')
       expect(ami.id).to eq('ami-1234567890EXAMPLE')
     end
+
+    context 'when the waiter times out' do
+      before do
+        allow(instance.aws_ec2_client).to receive(:wait_until)
+          .and_raise(Aws::Waiters::Errors::TooManyAttemptsError.new(40))
+      end
+
+      it 'warns with the image ID and returns the AMI' do
+        allow(Kernel).to receive(:warn)
+        ami = described_class.create(instance: instance, name: 'Test AMI')
+        expect(Kernel).to have_received(:warn).with(/ami-1234567890EXAMPLE/)
+        expect(ami.id).to eq('ami-1234567890EXAMPLE')
+      end
+    end
   end
 
   describe '#exists?' do

--- a/spec/capistrano/asg/rolling/ami_spec.rb
+++ b/spec/capistrano/asg/rolling/ami_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Capistrano::ASG::Rolling::AMI do
         expect(ami.id).to eq('ami-1234567890EXAMPLE')
       end
     end
-    
+
     it 'passes the configured delay and max_attempts to the waiter' do
       Capistrano::ASG::Rolling::Configuration.set(:asg_ami_wait_delay, 5)
       Capistrano::ASG::Rolling::Configuration.set(:asg_ami_wait_max_attempts, 3)

--- a/spec/capistrano/asg/rolling/autoscale_group_spec.rb
+++ b/spec/capistrano/asg/rolling/autoscale_group_spec.rb
@@ -163,6 +163,17 @@ RSpec.describe Capistrano::ASG::Rolling::AutoscaleGroup do
       end
     end
 
+    context 'when AWS returns a ValidationError (e.g. AMI is pending)' do
+      before do
+        stub_request(:post, /amazonaws.com/)
+          .with(body: /Action=StartInstanceRefresh&AutoScalingGroupName=test-asg/).to_return(body: File.read('spec/support/stubs/StartInstanceRefresh.AMIPending.xml'), status: 400)
+      end
+
+      it 'raises a StartInstanceRefreshError exception' do
+        expect { group.start_instance_refresh(template) }.to raise_error(Capistrano::ASG::Rolling::StartInstanceRefreshError, "The AMI 'ami-12345' is pending.")
+      end
+    end
+
     context 'when min and max healthy percentage is set' do
       subject(:group) { described_class.new('test-asg', min_healthy_percentage: 50, max_healthy_percentage: 110) }
 

--- a/spec/support/stubs/StartInstanceRefresh.AMIPending.xml
+++ b/spec/support/stubs/StartInstanceRefresh.AMIPending.xml
@@ -1,0 +1,8 @@
+<ErrorResponse xmlns="http://autoscaling.amazonaws.com/doc/2011-01-01/">
+  <Error>
+    <Type>Sender</Type>
+    <Code>ValidationError</Code>
+    <Message>The AMI 'ami-12345' is pending.</Message>
+  </Error>
+  <RequestId>ab45c1a5-1ed4-46ec-92f8-04029d6fc676</RequestId>
+</ErrorResponse>


### PR DESCRIPTION
## Summary

Two small fixes to make failure modes around AMI creation and Instance Refresh more diagnosable and easier to handle.

### 1. Warn when the AMI waiter times out

`AMI.create` rescues `Aws::Waiters::Errors::TooManyAttemptsError` silently and continues, on the assumption that the AMI will eventually become available. In practice — most commonly after increasing the root volume size of the source instance — the AMI is still in the `pending` state when the subsequent `start_instance_refresh` runs, which AWS rejects with `ValidationError: ... is pending`. The operator has no signal that the waiter ran out; the first thing they see is the refresh failure.

This PR adds a `Kernel.warn` on the rescue including the image ID, so it's visible in the deploy output that the waiter did not complete in time.

### 2. Wrap all AutoScaling service errors in `StartInstanceRefreshError`

`AutoscaleGroup#start_instance_refresh` only wraps `Aws::AutoScaling::Errors::InstanceRefreshInProgress`. The rake task at `lib/capistrano/asg/tasks/rolling.rake` rescues only `StartInstanceRefreshError`, so any other AWS service error (`ValidationError`, throttling, etc.) aborts the whole deploy instead of letting the existing per-ASG error handling continue with the remaining groups.

This PR widens the rescue to `Aws::AutoScaling::Errors::ServiceError`, the common parent of all AWS Auto Scaling service errors. `InstanceRefreshInProgress` is a subclass so existing behaviour is preserved.

## Test plan

- [x] `bundle exec rspec` — 143 examples, 0 failures (adds 2 specs)
- [x] `bundle exec rubocop lib spec` — no offenses
- [x] New spec verifies the warn is emitted with the image ID
- [x] New spec verifies a `ValidationError` ("AMI is pending") is wrapped in `StartInstanceRefreshError`