### PR TITLE
Aggregate errors in Parallel.run instead of abandoning in-flight threads

### DIFF
--- a/lib/capistrano/asg/rolling/parallel.rb
+++ b/lib/capistrano/asg/rolling/parallel.rb
@@ -9,18 +9,34 @@ module Capistrano
       module Parallel
         module_function
 
+        # Runs the given block once per element of `work`, in parallel.
+        #
+        # All threads are joined before this method returns, so a failure in one
+        # block does not abandon the other in-flight threads. If any block
+        # raises, the first error is re-raised after all threads have completed;
+        # additional errors are surfaced via `Kernel.warn`.
         def run(work)
-          result = Concurrent::Array.new
+          results = Concurrent::Array.new
+          errors = Concurrent::Array.new
 
           threads = work.map do |w|
             Thread.new do
-              result << yield(w)
+              results << yield(w)
+            rescue StandardError => e
+              errors << e
             end
           end
 
           threads.each(&:join)
 
-          result
+          if errors.any?
+            errors.drop(1).each do |e|
+              Kernel.warn("WARNING: parallel task failed: #{e.class}: #{e.message}")
+            end
+            raise errors.first
+          end
+
+          results
         end
       end
     end

--- a/spec/capistrano/asg/rolling/parallel_spec.rb
+++ b/spec/capistrano/asg/rolling/parallel_spec.rb
@@ -11,5 +11,32 @@ RSpec.describe Capistrano::ASG::Rolling::Parallel do
       result = described_class.run([1, 2, 3, 4]) { |n| n * 2 }
       expect(result).to be_a(Concurrent::Array)
     end
+
+    context 'when a block raises' do
+      let(:completed) { Concurrent::Array.new }
+      let(:work) do
+        lambda do |w|
+          raise 'boom' if w == :fail
+
+          sleep 0.05
+          completed << w
+        end
+      end
+
+      it 'waits for the other blocks to finish before re-raising' do
+        expect { described_class.run(%i[fail ok ok], &work) }.to raise_error(RuntimeError, 'boom')
+        expect(completed.size).to eq(2)
+      end
+
+      it 'warns for additional errors beyond the first' do
+        allow(Kernel).to receive(:warn)
+
+        expect do
+          described_class.run([1, 2]) { |n| raise "boom #{n}" }
+        end.to raise_error(RuntimeError, /boom/)
+
+        expect(Kernel).to have_received(:warn).with(/parallel task failed.*boom/).once
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

`Parallel.run` joins each thread in order via `threads.each(&:join)`. `Thread#join` re-raises in the joining thread if the thread terminated with an exception, so the first failure abandons the remaining (still running) threads. When a deployment is creating AMIs in parallel for multiple Auto Scaling Groups, a single `create_image` failure aborts the deploy while the other `create_image` calls are still in flight against AWS — leaving orphaned AMI builds that nothing tracks or cleans up, and only the first error is visible to the operator.

This PR changes `Parallel.run` so it:

- catches `StandardError` inside each thread and stores it in a `Concurrent::Array`
- always joins every thread before checking for errors
- re-raises the first error after all threads have completed
- surfaces additional errors via `Kernel.warn` so they're visible alongside the one raised

The return type (`Concurrent::Array`) and the happy-path behaviour are unchanged.

## Test plan

- [x] `bundle exec rspec` — 143 examples, 0 failures (adds 2 specs)
- [x] `bundle exec rubocop lib spec` — no offenses
- [x] New spec: when one block raises, the others run to completion before the error is re-raised
- [x] New spec: when multiple blocks raise, additional errors are surfaced via `Kernel.warn`