### PR TITLE
Recover from AWS throttling during instance refresh polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,14 @@ Enable or disable auto-rollback on instance refreshes (default: false):
 set :asg_instance_refresh_auto_rollback, true
 ```
 
+The AWS clients are configured with `adaptive` retry mode and a retry limit of 10 by default, so transient throttling (`Aws::AutoScaling::Errors::Throttling: Rate exceeded`) does not abort a deployment. You can tune both:
+
+```ruby
+# config/deploy.rb
+set :asg_aws_retry_mode, 'adaptive' # default; one of 'legacy', 'standard', 'adaptive'
+set :asg_aws_retry_limit, 10        # default
+```
+
 ## Usage
 
 Specify the Auto Scaling Groups with the keyword `autoscale` instead of using the `server` keyword in Capistrano's stage configuration. Provide the name of the Auto Scaling Group and any properties you want to pass to the server:

--- a/lib/capistrano/asg/rolling/aws.rb
+++ b/lib/capistrano/asg/rolling/aws.rb
@@ -22,6 +22,8 @@ module Capistrano
           options = {}
           options[:region] = aws_region if aws_region
           options[:credentials] = aws_credentials if aws_credentials.set?
+          options[:retry_mode] = Configuration.aws_retry_mode
+          options[:retry_limit] = Configuration.aws_retry_limit
           options[:http_wire_trace] = true if ENV['AWS_HTTP_WIRE_TRACE'] == '1'
           options
         end

--- a/lib/capistrano/asg/rolling/configuration.rb
+++ b/lib/capistrano/asg/rolling/configuration.rb
@@ -87,7 +87,7 @@ module Capistrano
         def aws_retry_limit
           fetch(:asg_aws_retry_limit, 10)
         end
-        
+
         def ami_wait_delay
           fetch(:asg_ami_wait_delay, 15)
         end

--- a/lib/capistrano/asg/rolling/configuration.rb
+++ b/lib/capistrano/asg/rolling/configuration.rb
@@ -79,6 +79,14 @@ module Capistrano
         def instance_refresh_polling_interval
           fetch(:asg_instance_refresh_polling_interval, 30)
         end
+
+        def aws_retry_mode
+          fetch(:asg_aws_retry_mode, 'adaptive')
+        end
+
+        def aws_retry_limit
+          fetch(:asg_aws_retry_limit, 10)
+        end
       end
     end
   end

--- a/lib/capistrano/asg/tasks/rolling.rake
+++ b/lib/capistrano/asg/tasks/rolling.rake
@@ -202,6 +202,12 @@ namespace :rolling do
           else
             logger.info "Auto Scaling Group: **#{name}**, status '#{refresh.status}'."
           end
+        rescue Aws::AutoScaling::Errors::ServiceError => e
+          # The instance refresh is still running in AWS even though we hit a
+          # transient API error (typically throttling that exceeded the SDK's
+          # retry budget). Log and retry on the next polling interval instead
+          # of aborting the deployment.
+          logger.warning "Auto Scaling Group: **#{name}**, failed to fetch status: #{e.class}: #{e.message} — retrying on next poll."
         end
         next if groups.empty?
 

--- a/spec/capistrano/asg/rolling/aws_spec.rb
+++ b/spec/capistrano/asg/rolling/aws_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.describe Capistrano::ASG::Rolling::AWS do
+  let(:klass) do
+    Class.new do
+      include Capistrano::ASG::Rolling::AWS
+    end
+  end
+
+  describe '#aws_options' do
+    subject(:options) { klass.new.send(:aws_options) }
+
+    it 'sets adaptive retry mode by default' do
+      expect(options[:retry_mode]).to eq('adaptive')
+    end
+
+    it 'sets a retry limit of 10 by default' do
+      expect(options[:retry_limit]).to eq(10)
+    end
+
+    context 'when overridden via Capistrano variables' do
+      before do
+        allow(Capistrano::ASG::Rolling::Configuration).to receive_messages(aws_retry_mode: 'standard', aws_retry_limit: 25)
+      end
+
+      it 'passes the configured retry_mode and retry_limit through' do
+        expect(options[:retry_mode]).to eq('standard')
+        expect(options[:retry_limit]).to eq(25)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #9.

## Summary

Issue #9 reports `Aws::AutoScaling::Errors::Throttling: Rate exceeded` aborting deployments while the Instance Refresh keeps running in AWS in the background. The root cause is that `Aws::AutoScaling::Client` and `Aws::EC2::Client` are constructed in `lib/capistrano/asg/rolling/aws.rb` with no retry config, so they fall back to the AWS SDK default of 3 standard retries — not enough for sustained API throttling on a busy account, particularly during the `rolling:instance_refresh_status` polling loop which hammers `DescribeInstanceRefreshes` for every ASG every few seconds.

This PR addresses it in two layers:

### 1. Configure adaptive retry mode on the AWS clients

`adaptive` retry mode is the AWS-recommended strategy for rate-limit-sensitive workloads: it adds client-side rate limiting on top of exponential backoff, dynamically slowing requests in response to throttling responses instead of just blindly retrying. This affects every AWS call in the gem, not just polling.

Two new Capistrano variables:

- `:asg_aws_retry_mode` — one of `legacy`, `standard`, `adaptive` (default: `adaptive`)
- `:asg_aws_retry_limit` — default: `10` (SDK default is 3)

### 2. Tolerate throttling in the polling loop

Even with 10 adaptive retries, a really bad throttling burst could still exhaust the budget. In `rolling:instance_refresh_status` the instance refresh has already been started in AWS by that point — losing the deploy is much worse than losing one poll cycle. The polling loop now rescues `Aws::AutoScaling::Errors::ServiceError` per-group, logs a warning, and retries on the next interval instead of aborting.

## Test plan

- [x] \`bundle exec rspec\` — 144 examples, 0 failures (adds 3 specs covering retry config defaults and override)
- [x] \`bundle exec rubocop lib spec\` — no offenses
- [x] README updated with the two new configuration variables