### PR TITLE
Use ASCII hyphen in throttle-recovery log message

### DIFF
--- a/lib/capistrano/asg/tasks/rolling.rake
+++ b/lib/capistrano/asg/tasks/rolling.rake
@@ -207,7 +207,7 @@ namespace :rolling do
           # transient API error (typically throttling that exceeded the SDK's
           # retry budget). Log and retry on the next polling interval instead
           # of aborting the deployment.
-          logger.warning "Auto Scaling Group: **#{name}**, failed to fetch status: #{e.class}: #{e.message} — retrying on next poll."
+          logger.warning "Auto Scaling Group: **#{name}**, failed to fetch status: #{e.class}: #{e.message} - retrying on next poll."
         end
         next if groups.empty?
 


### PR DESCRIPTION
## Summary

Line 210 of `lib/capistrano/asg/tasks/rolling.rake`, introduced in #15, contains a U+2014 em-dash inside the new `logger.warning` for the AWS throttling recovery branch:

```ruby
logger.warning "Auto Scaling Group: ... #{e.message} — retrying on next poll."
```

When Capistrano loads `.rake` files on hosts whose default Ruby source encoding falls back to US-ASCII (some Bundler/Capistrano setups), the parser aborts with:

```
SyntaxError: .../bundler/gems/capistrano-asg-rolling-ede1405ee0a9/lib/capistrano/asg/tasks/rolling.rake:210: syntax error found
> 210 | ...  - retrying on next poll."
      |     ^~~ invalid multibyte character 0xE2
```

Swap the em-dash for an ASCII hyphen so the file stays ASCII-clean regardless of the host's source-encoding defaults. One-line, message-only change — no behaviour difference.

## Test plan

- [x] `ruby -c lib/capistrano/asg/tasks/rolling.rake` reports `Syntax OK`.